### PR TITLE
Dpd-143 fix logging bug when writing to disk

### DIFF
--- a/src/log/isxLogger.cpp
+++ b/src/log/isxLogger.cpp
@@ -1,4 +1,5 @@
 #include "isxLogger.h"
+#include "isxUtilities.h"
 
 #include <iostream>
 #include <fstream>
@@ -21,6 +22,12 @@ namespace isx {
                 m_filename = inLogFileName;
                 m_appName = inAppName;
                 m_appVersion = inAppVersion;
+
+                // Ensure the path exists
+                if (!isx::pathExists(isx::getDirName(m_filename)))
+                {
+                    isx::makeDirectory(isx::getDirName(m_filename));
+                }
 
                 // remove previous log file if existent
                 std::remove(m_filename.c_str());


### PR DESCRIPTION
## Description
Fix bug in logging module where the first few messages logged were not written to disk

## Changes
Create log directory if it doesn't not exist when the logger is initialized. This directory (the output directory) is created in `cnmfe.cpp` after the logger is initialized which is why we saw this undefined behaviour where the first few lines were not written to disk.

## Testing
Tested on Mac, Linux, and Windows. Verified log file from `runCnmfe` contains systems info for all operating systems. Here is an example log file I generated: [Inscopix_CNMFe_Log.txt](https://github.com/inscopix/isx-cnmfe/files/7181237/Inscopix_CNMFe_Log.txt)