### PR TITLE
DPD-178 handle case where no cells are identified by CNMF-E

### DIFF
--- a/src/exposed/cnmfe.cpp
+++ b/src/exposed/cnmfe.cpp
@@ -98,9 +98,13 @@ namespace isx
         patchCnmfe(movie, memoryMapPath, footprints, traces, deconvParams, initParams, spatialParams, patchParams,
            maxNumNeurons, ringSizeFactor, mergeThreshold, numIterations, numThreads, outputType, deconvolve);
 
-        // if output directory provided, save output files to disk
-        if (!outputDirPath.empty())
+        if (footprints.n_slices == 0 || traces.n_rows == 0)
         {
+            ISX_LOG_WARNING("No components were identified by CNMF-E");
+        }
+        else if (!outputDirPath.empty())
+        {
+            // if an output directory was provided and cells were identified, save output files to disk
             if (outputFiletype == 1)
             {
                 std::string outputFilename = getH5OutputFilename(inputMoviePath, outputDirPath);


### PR DESCRIPTION
CNMF-E isn't guaranteed to identify cells. This can occur when the parameters aren't optimal or when the input data doesn't contain signal that conform to the expectations of neuronal activity defined in the CNMF-E model.

- **Problem**: When no cells are identified, the user is not alerted and an empty tiff file gets generated to store the footprints.
- **Solution**: Display a warning message (when verbose mode is enabled), log such warning message, and prevent the saving of empty output files.
- **Testing**: Tested on Mac OS Catalina, Python 3.9, using dataset "cnmfe_test_dataset_3.tiff" with default parameters and specifying to save the output to disk.