### PR TITLE
DPD-185 update version to 1.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ class CMakeBuild(build_ext):
             )
 
 setup(name='inscopix-cnmfe',
-      version='1.0.0',
+      version='1.0.1',
       author='Inscopix, Inc.',
       author_email="support@inscopix.com",
       url="https://github.com/inscopix/isx-cnmfe",

--- a/src/api/pythonAPI.cpp
+++ b/src/api/pythonAPI.cpp
@@ -123,6 +123,7 @@ std::tuple<py::array,py::array> isx_cnmfe_python(
 PYBIND11_MODULE(inscopix_cnmfe, handle)
 {
     handle.doc() = "Inscopix CNMF-E for automated source extraction";
+    handle.attr("__version__") = "1.0.1";
     handle.def("run_cnmfe", &isx_cnmfe_python, R"mydelimiter(
     Run the CNMF-E cell identification algorithm on a movie
 

--- a/src/exposed/cnmfe.cpp
+++ b/src/exposed/cnmfe.cpp
@@ -39,7 +39,7 @@ namespace isx
         const std::string timeStamp = getCurrentDateTime("%Y%m%d-%H%M%S", false);
         const std::string logFileName = outputDirPath.empty() ? "" : outputDirPath + "/" + "Inscopix_CNMF-E_Log_" + timeStamp + ".txt";
         const std::string appName = "Inscopix CNMF-E";
-        const std::string appVersion = "1.0.0";
+        const std::string appVersion = "1.0.1";
         const bool verboseEnabled = verbose==1 ? true : false;
         Logger::initialize(logFileName, appName, appVersion, verboseEnabled);
 


### PR DESCRIPTION
- Version updated from 1.0.0 to 1.0.1.
- In a future PR (DPD-183), we will automate this and centralize this value to have it defined in a single place.
- Version now available at the package level using the code below:
```
import inscopix_cnmfe
print(inscopix_cnmfe.__version__)  # will print "1.0.1"
```
- Tested on Mac OS Catalina, Python 3.6, in both Python and CPP