### PR TITLE
Fixed typo in src/isxCnmfeCore.cpp

### DIFF
--- a/src/core/isxCnmfeCore.cpp
+++ b/src/core/isxCnmfeCore.cpp
@@ -153,7 +153,7 @@ namespace isx
 
     float Cnmfe::getMergeThreshold()
     {
-        return m_ringSizeFactor;
+        return m_mergeThresh;
     }
 
     size_t Cnmfe::getNumIterations()


### PR DESCRIPTION
Typo as mentioned in Issue #69. Should be a pretty straight forward fix. 